### PR TITLE
Dehardcode home directory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,13 +18,13 @@ resource "null_resource" "vyos_config" {
 	}
 	provisioner "file" {
 		content		= local.config_string
-		destination	= "/home/vyos/config.cfg"
+		destination	= "/home/${local.mgmt_username}/config.cfg"
 	}
 	provisioner "remote-exec" {
 		inline = [<<-EOT
 			#!/bin/vbash
 			source /opt/vyatta/etc/functions/script-template
-			source /home/vyos/config.cfg
+			source $HOME/config.cfg
 			commit
 			save
 		EOT


### PR DESCRIPTION
If we do not use the user `vyos`, it is a good idea to rely on the real user who configures the router and use user's homedir
Fixes the issue if we try to configure from the user `admin`
```
module.router_config["r2"].null_resource.vyos_config: Provisioning with 'file'...
\u2577
\u2502 Error: file provisioner error
\u2502 
\u2502   with module.router_config["r1"].null_resource.vyos_config,
\u2502   on .terraform/modules/router_config/main.tf line 19, in resource "null_resource" "vyos_config":
\u2502   19: 	provisioner "file" {
\u2502 
\u2502 Upload failed: scp: /home/vyos: Permission denied
\u2575

```